### PR TITLE
Remove legacy-peer-deps from CI workflows

### DIFF
--- a/.github/workflows/angular-ghpages-deploy.yml
+++ b/.github/workflows/angular-ghpages-deploy.yml
@@ -26,6 +26,6 @@ jobs:
         CLI: true
         GH_TOKEN: ${{ secrets.GH_TOKEN }}
       run: |
-        npm ci --legacy-peer-deps
+        npm ci
         npm run build
         npm run deploy

--- a/.github/workflows/angular-ghpages-deploy.yml
+++ b/.github/workflows/angular-ghpages-deploy.yml
@@ -14,6 +14,8 @@ jobs:
   build-and-deploy:
     needs: [main-ci-tests]
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
     - name: Checkout
       uses: actions/checkout@v6

--- a/.github/workflows/auto-package-updates.yml
+++ b/.github/workflows/auto-package-updates.yml
@@ -11,6 +11,8 @@ permissions:
 jobs:
   package-update:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
     - name: Checkout
       uses: actions/checkout@v6

--- a/.github/workflows/cypress-e2e-tests.yml
+++ b/.github/workflows/cypress-e2e-tests.yml
@@ -13,8 +13,8 @@ jobs:
       uses: actions/setup-node@v6
       with:
         node-version: 'lts/*'
-    - name: Install w/ legacy-peer-deps
-      run: npm ci --legacy-peer-deps
+    - name: Install Dependencies
+      run: npm ci
     - name: Run Cypress E2E Tests
       uses: cypress-io/github-action@v7
       with:

--- a/.github/workflows/cypress-e2e-tests.yml
+++ b/.github/workflows/cypress-e2e-tests.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   cypress-test:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
     - name: Checkout
       uses: actions/checkout@v6

--- a/.github/workflows/jest-tests.yml
+++ b/.github/workflows/jest-tests.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   jest-test:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
     - name: Checkout
       uses: actions/checkout@v6

--- a/.github/workflows/jest-tests.yml
+++ b/.github/workflows/jest-tests.yml
@@ -14,8 +14,8 @@ jobs:
       with:
         node-version: 'lts/*'
         cache: 'npm'
-    - name: Install dependencies with legacy-peer-deps
-      run: npm ci --legacy-peer-deps
+    - name: Install Dependencies
+      run: npm ci
     - name: Install Chrome
       uses: browser-actions/setup-chrome@v2
     - name: Run Jest unit tests


### PR DESCRIPTION
Replace npm ci --legacy-peer-deps with npm ci and standardize the install step name to "Install Dependencies" in .github/workflows/angular-ghpages-deploy.yml, cypress-e2e-tests.yml, and jest-tests.yml. This simplifies the CI steps and assumes the project's dependency tree is compatible with the default npm behavior.