### PR TITLE
Add auto-approve workflow for owner's PRs

### DIFF
--- a/.github/workflows/auto-approve-own-pr.yml
+++ b/.github/workflows/auto-approve-own-pr.yml
@@ -1,0 +1,20 @@
+name: Auto-approve own Pull Request
+
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch: # Allows manual runs
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.pull_request.user.login == github.repository_owner
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Auto-approve PR
+        run: gh pr review ${{ github.event.pull_request.number }} --approve
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/auto-approve-owner-pr.yml
+++ b/.github/workflows/auto-approve-owner-pr.yml
@@ -1,4 +1,4 @@
-name: Auto-approve own Pull Request
+name: Auto-approve Owner's Pull Requests
 
 on:
   pull_request:


### PR DESCRIPTION
Add a GitHub Actions workflow that auto-approves pull requests opened by the repository owner on the main branch (and can be run manually). The job runs on ubuntu-latest, checks out the repo, requires pull-requests: write permission, and executes `gh pr review ${{ github.event.pull_request.number }} --approve` with GITHUB_TOKEN set to ${{ github.token }}. The workflow is gated by an if-condition ensuring the PR author matches the repository owner.