### PR TITLE
Enhance GitHub Actions workflows and npmrc

### DIFF
--- a/.github/workflows/angular-ghpages-deploy.yml
+++ b/.github/workflows/angular-ghpages-deploy.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   checks: write
   pull-requests: write
+  contents: write
 
 jobs:
   main-ci-tests:
@@ -23,6 +24,7 @@ jobs:
       uses: actions/setup-node@v6
       with:
         node-version: 'lts/*'
+        cache: 'npm'
     - name: Build and Deploy
       env:
         CLI: true
@@ -31,3 +33,13 @@ jobs:
         npm ci
         npm run build
         npm run deploy
+    - name: Verify deployment
+      if: always()
+      run: |
+        if [ -d "dist/portfolio/browser" ]; then
+          echo "✅ Build artifacts exist"
+          du -sh dist/portfolio/browser
+        else
+          echo "⚠️ Build artifacts not found"
+          exit 1
+        fi

--- a/.github/workflows/auto-package-updates.yml
+++ b/.github/workflows/auto-package-updates.yml
@@ -3,6 +3,7 @@ name: Automated Package Updates
 on:
   schedule:
     - cron: '0 2 * * 1,3,5'
+  workflow_dispatch: # Allows manual runs
 
 permissions:
   contents: write
@@ -20,12 +21,13 @@ jobs:
       uses: actions/setup-node@v6
       with:
         node-version: 'lts/*'
+        cache: 'npm'
     - name: Install npm-check-updates
       run: npm install -g npm-check-updates
     - name: Update Packages and Install
       run: |
           ncu -t minor -u
-          npm install
+          npm ci
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v8
       with:

--- a/.github/workflows/cypress-e2e-tests.yml
+++ b/.github/workflows/cypress-e2e-tests.yml
@@ -15,6 +15,7 @@ jobs:
       uses: actions/setup-node@v6
       with:
         node-version: 'lts/*'
+        cache: 'npm'
     - name: Install Dependencies
       run: npm ci
     - name: Run Cypress E2E Tests
@@ -24,3 +25,13 @@ jobs:
         start: npm start
         browser: chrome
         record: false
+    - name: Upload Cypress artifacts on failure
+      if: failure()
+      uses: actions/upload-artifact@v6
+      with:
+        name: cypress-artifacts
+        path: |
+          cypress/screenshots/
+          cypress/videos/
+        retention-days: 7
+        if-no-files-found: ignore

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
Add npm caching and reliability improvements across CI workflows: enable 'cache: npm' for setup-node in deploy, auto-update and cypress workflows; add contents: write permission and a post-build verification step to the Angular GH Pages deploy workflow to ensure build artifacts exist; allow manual runs of the package-update workflow via workflow_dispatch and replace npm install with npm ci for reproducible installs; upload Cypress screenshots/videos on failure to aid debugging; add .npmrc with legacy-peer-deps=true to relax peer dependency resolution during installs.