### PR TITLE
Use npm install instead of npm ci in workflow

### DIFF
--- a/.github/workflows/auto-package-updates.yml
+++ b/.github/workflows/auto-package-updates.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Update Packages and Install
       run: |
           ncu -t minor -u
-          npm ci
+          npm install
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v8
       with:


### PR DESCRIPTION
Update the auto-package-updates GitHub Actions job to run npm install after running ncu -t minor -u so the package-lock and node_modules are updated to reflect changes in package.json before creating the PR.