### PR TITLE
fix: optimize dependabot config to prevent 55-minute timeout

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    allow:
+      - dependency-type: "production"
+    open-pull-requests-limit: 5
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
- Limit to production dependencies only to reduce dependency tree complexity
- Set open-pull-requests-limit to 5 to reduce processing overhead
- These changes should prevent Dependabot from hitting the timeout during dependency resolution